### PR TITLE
A proposal to rename Hipo Lake

### DIFF
--- a/src/main/java/me/pesekjak/hippo/Hippo.java
+++ b/src/main/java/me/pesekjak/hippo/Hippo.java
@@ -30,7 +30,7 @@ public class Hippo extends JavaPlugin {
     //                    (____⳹       /
     //                          ⳹      ⳹
     //                           '-'-'-'
-    // MIGHTY HIPPO FROM THE HIPO LAKE
+    // MIGHTY HIPPO FROM THE HIPPO LAKE
 
     private static Hippo instance;
     private static SkriptAddon addonInstance;


### PR DESCRIPTION
Many geographical areas, including lakes, get their names from various properties of said areas. A common practice even for lakes, this allows any person or people who read or hear the name to immediately identify charasteristics of the area. I propose that this scheme for naming areas also be used for the lake in which the Hippo sleeps, and consequently also wakes up from and goes to sleep to.

As it stands, the name of the lake is registered as "Hipo Lake" (as per the comment on line 33 of Hippo.java). This can be confusing for many readers, as the lake is not said to contain any "Hipos", but instead at least one Hippo. I propose, then, that the name of Hipo Lake be changed to Hippo Lake.

A possible counter-argument to mine is that the property of containing at least one hippo ought not to decide the name of a lake in its entirety. Is it not possible for the lake to contain several Hipos, which are simply not mentioned? While this is possible, these Hipos are of little relevance in the context of this particular codebase. Additionally, the lake is also only relevant within the context of this codebase. Finally, the codebase is primarily focused specifically on Hippos, and not Hipos, and as such, it is only reasonable to conclude that the given counter-argument is not relevant when choosing a name for the lake within the context of this codebase.

In conclusion, as it stands, the name "Hipo Lake" is rather confusing, and can even be seen as an unintentional misspelling as "Hippo Lake". As such, I think it prudent that Hipo Lake be immediately renamed to Hippo Lake to avoid confusion.